### PR TITLE
fix dashboard dispute filters dropdown resize issue

### DIFF
--- a/src/components/Disputes/DisputeFilters.js
+++ b/src/components/Disputes/DisputeFilters.js
@@ -30,6 +30,7 @@ const DisputeFilters = ({
         placeholder="Phase"
         selected={phaseFilter}
         onChange={onPhaseChange}
+        wide
         items={phaseTypes}
       />
       <DropDown
@@ -38,6 +39,7 @@ const DisputeFilters = ({
         selected={statusFilter}
         onChange={onStatusChange}
         items={statusTypes}
+        wide
       />
       <DropDown
         header="Creator of the dispute"
@@ -45,6 +47,7 @@ const DisputeFilters = ({
         selected={selectedSubject}
         onChange={onSubjectChange}
         items={subjects}
+        wide
       />
       <DateRangePicker
         startDate={dateRangeFilter.start}


### PR DESCRIPTION
This PR addresses https://linear.app/aragon/issue/ARA2-123/design-issue-on-protocol-dashboard

The issue was the dropdown was resizing based on the dropdown menu content width.  The wide attribute in the Button component disables the resize by content width.

