### PR TITLE
fix: properly integrated decentralized subgraph

### DIFF
--- a/src/environment.js
+++ b/src/environment.js
@@ -40,6 +40,9 @@ const ENV_VARS = {
   SUBGRAPH_NAME() {
     return process.env.REACT_APP_SUBGRAPH_NAME
   },
+  SUBGRAPH_API_KEY() {
+    return process.env.REACT_APP_SUBGRAPH_API_KEY
+  },
   ETHERSCAN_ENDPOINT() {
     return process.env.REACT_APP_ETHERSCAN_ENDPOINT
   }

--- a/src/networks.js
+++ b/src/networks.js
@@ -20,7 +20,7 @@ export const networkConfigs = {
     nodes: {
       defaultEth: 'https://mainnet.eth.aragon.network/',
       subgraph:
-        'https://api.studio.thegraph.com/query/82696/aragon-court-v2-mainnet/version/latest',
+        `https://gateway-arbitrum.network.thegraph.com/api/${environment('SUBGRAPH_API_KEY')}/subgraphs/id/2U7z4qy1jxQ5b9aE7o2C41CJN4kSaAEfM876nk9Hu6wA`,
     },
   },
   rinkeby: {


### PR DESCRIPTION
The previous change wasn't complete and didn't work.
This pull corrects the previous mistake and adds a new env variable `REACT_APP_SUBGRAPH_API_KEY` to define the API key used for the decentralized subgraph solution during build time.